### PR TITLE
Invert coordinates to plot lower triangle from upper triangle bricks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: HiCBricks
 Title: Framework for Storing and Accessing Hi-C Data Through HDF Files
-Version: 1.15.1
+Version: 1.15.1.9001
 Description: HiCBricks is a library designed for handling large high-resolution Hi-C datasets. Over the years, the Hi-C field has experienced a rapid increase in the size and complexity of datasets. HiCBricks is meant to overcome the challenges related to the analysis of such large datasets within the R environment. HiCBricks offers user-friendly and efficient solutions for handling large high-resolution Hi-C datasets. The package provides an R/Bioconductor framework with the bricks to build more complex data analysis pipelines and algorithms. HiCBricks already incorporates example algorithms for calling domain boundaries and functions for high quality data visualization.
 Date: 2019-08-24
 Type: Package

--- a/R/viz_art_backend.R
+++ b/R/viz_art_backend.R
@@ -462,18 +462,18 @@ Get_heatmap_theme <- function(x_axis=TRUE, y_axis=TRUE,
                 panel.grid.minor=element_blank(),
                 panel.grid.major=element_blank(),
                 panel.background = element_blank(),
-                axis.title.x=x_axis.text,
-                axis.title.y=y_axis.text,
+                axis.title.x = x_axis.text,
+                axis.title.y = y_axis.text,
                 axis.text.x = x_axis.text,
-                axis.text.y = x_axis.text,
+                axis.text.y = y_axis.text,
                 axis.ticks.x = x_axis.ticks,
                 axis.ticks.y = y_axis.ticks,
                 legend.position="bottom",
                 legend.key.height = legend_key_height,
                 legend.key.width = legend_key_width,
-                legend.title=element_text(size=legend_title_text_size),
-                legend.text=element_text(size=legend_text_size),
-                plot.title=element_text(size=title_size))
+                legend.title = element_text(size=legend_title_text_size),
+                legend.text = element_text(size=legend_text_size),
+                plot.title = element_text(size=title_size))
     return(Brick_theme)
 }
 

--- a/R/viz_art_functions.R
+++ b/R/viz_art_functions.R
@@ -190,151 +190,153 @@
 #' value_cap = 0.99, width = 10, height = 11, legend_key_width = unit(3,"mm"),
 #' legend_key_height = unit(0.3,"cm"))
 #' 
-Brick_vizart_plot_heatmap = function(File, Bricks, resolution,
-    x_coords, y_coords, FUN = NULL, value_cap = NULL, 
-    distance = NULL, rotate = FALSE, x_axis = TRUE, x_axis_title = NULL, 
-    y_axis = TRUE, y_axis_title = NULL, title = NULL, legend_title = NULL, 
-    return_object=FALSE, x_axis_num_breaks = 5, y_axis_num_breaks = 5, 
-    palette, col_direction = 1, extrapolate_on = NULL, 
+Brick_vizart_plot_heatmap <- function (File, Bricks, resolution,
+    x_coords, y_coords, FUN = NULL, value_cap = NULL,
+    distance = NULL, rotate = FALSE, x_axis = TRUE,  x_axis_title = NULL,
+    y_axis = TRUE, y_axis_title = NULL, title = NULL, legend_title = NULL,
+    return_object = FALSE, x_axis_num_breaks = 5, y_axis_num_breaks = 5,
+    palette, col_direction = 1, extrapolate_on = NULL,
     x_axis_text_size = 10, y_axis_text_size = 10, text_size = 10,
     legend_title_text_size = 8, legend_text_size = 8, title_size = 10,
     tad_ranges = NULL, group_col = NULL, tad_colour_col = NULL, colours = NULL,
-    colours_names = NULL, cut_corners = FALSE, highlight_points = NULL, 
-    width = 10, height = 6, line_width = 0.5, units = "cm", 
-    legend_key_width = unit(3,"cm"), legend_key_height = unit(0.5,"cm")){
-
-    if(!is.list(Bricks)){
+    colours_names = NULL, cut_corners = FALSE, highlight_points = NULL,
+    width = 10, height = 6, line_width = 0.5, units = "cm",
+    legend_key_width = unit(3, "cm"), legend_key_height = unit(0.5,"cm")){
+    if (!is.list(Bricks)) {
         stop("Bricks expects an argument of type list.",
-            " Please refer to the vignette to understand the parameter.")
+             " Please refer to the vignette to understand the parameter.")
     }
-    Matrix.df <- Get_one_or_two_brick_regions(Bricks = Bricks, 
-        resolution = resolution, x_coords = x_coords, 
-        y_coords = y_coords, distance = distance,
-        value_cap = value_cap, FUN = FUN)
-    if(nrow(Matrix.df)==0){
+    Matrix.df <- HiCBricks:::Get_one_or_two_brick_regions(Bricks = Bricks,
+        resolution = resolution, x_coords = x_coords, y_coords = y_coords,
+        distance = distance, value_cap = value_cap, FUN = FUN)
+    if (nrow(Matrix.df) == 0) {
         stop("The matrix was empty!")
     }
-    list_of_coords <- list("x_coords" = x_coords, "y_coords" = y_coords)
-
-    Parsed_string <- ._Parse_genomic_coordinates(list_of_coords)
+    list_of_coords <- list(x_coords = x_coords, y_coords = y_coords)
+    print(list_of_coords)
+    Parsed_string <- HiCBricks:::._Parse_genomic_coordinates(list_of_coords)
     x.coord.parsed <- Parsed_string[["x_coords"]]
     y.coord.parsed <- Parsed_string[["y_coords"]]
-    x.coord.breaks <- make_axis_coord_breaks(from = min(Matrix.df$row), 
-        to = max(Matrix.df$row), how.many = x_axis_num_breaks, 
+    print(x.coord.parsed)
+    print(y.coord.parsed)
+    x.coord.breaks <- HiCBricks:::make_axis_coord_breaks(from = min(Matrix.df$row),
+        to = max(Matrix.df$row), how.many = x_axis_num_breaks,
         two.sample = FALSE)
-    x_axis.coord.labs <- Make_axis_labels(Brick = Bricks[[1]], 
-        resolution = resolution, chr = x.coord.parsed['chr'], 
+    print(x.coord.breaks)
+    x_axis.coord.labs <- HiCBricks:::Make_axis_labels(Brick = Bricks[[1]],
+        resolution = resolution, chr = x.coord.parsed["chr"],
         positions = x.coord.breaks)
-
-    two.sample <- (rotate & length(Bricks)==2)
-    y.coord.breaks <- make_axis_coord_breaks(from = min(Matrix.df$row), 
-        to = max(Matrix.df$row), how.many = x_axis_num_breaks, 
+    print(x_axis.coord.labs)
+    two.sample <- (rotate & length(Bricks) == 2)
+    print(str(Matrix.df))
+    y.coord.breaks <- HiCBricks:::make_axis_coord_breaks(from = min(Matrix.df$col),
+        to = max(Matrix.df$col), how.many = y_axis_num_breaks,
         two.sample = two.sample)
-    y_axis.coord.labs <- Make_axis_labels(Brick = Bricks[[1]], 
-        resolution = resolution, chr = y.coord.parsed['chr'], 
+   print(y.coord.breaks)
+    y_axis.coord.labs <- HiCBricks:::Make_axis_labels(Brick = Bricks[[1]],
+        resolution = resolution, chr = y.coord.parsed["chr"],
         positions = abs(y.coord.breaks))
-
-    Colours <- Make_colours(palette = palette, 
-        extrapolate_on = extrapolate_on, direction = col_direction)
-    # go from min val to mid to max val
-    two.sample <- (length(Bricks)==2)
-    Matrix.df$rescale <- rescale_values_for_colours(
-        Object = Matrix.df, two.sample = two.sample)
-    Value.dist <- make_colour_breaks(Object = Matrix.df, 
-        how.many = length(Colours), two.sample = two.sample)
-    
-    Legend.breaks.list <- get_legend_breaks(Object = Matrix.df, 
+    print(y_axis.coord.labs)
+    Colours <- HiCBricks:::Make_colours(palette = palette, extrapolate_on = extrapolate_on,
+        direction = col_direction)
+    two.sample <- (length(Bricks) == 2)
+    Matrix.df$rescale <- HiCBricks:::rescale_values_for_colours(Object = Matrix.df,
+        two.sample = two.sample)
+    Value.dist <- HiCBricks:::make_colour_breaks(Object = Matrix.df, how.many = length(Colours),
+        two.sample = two.sample)
+    Legend.breaks.list <- HiCBricks:::get_legend_breaks(Object = Matrix.df,
         how.many = 5, value_cap = value_cap, colours = Colours,
         two.sample = two.sample)
     Colour.breaks <- Legend.breaks.list[["col.breaks"]]
     Colour.labs <- Legend.breaks.list[["col.labs"]]
     Colours <- Legend.breaks.list[["cols"]]
-    if(rotate){
+    if (rotate) {
         y.coord.breaks <- y.coord.breaks - min(y.coord.breaks)
         x.coord.breaks <- x.coord.breaks - min(x.coord.breaks)
-        if(length(Bricks)==2){
-            Upper.tri.map <- Matrix.df[Matrix.df$dist >= 0,]
-            Lower.tri.map <- Matrix.df[Matrix.df$dist <= 0,]
+        if (length(Bricks) == 2) {
+            Upper.tri.map <- Matrix.df[Matrix.df$dist >= 0, ]
+            Lower.tri.map <- Matrix.df[Matrix.df$dist <= 0, ]
             Lower.tri.map$dist <- abs(Lower.tri.map$dist)
-            Upper.rotated.map <- RotateHeatmap(Matrix=Upper.tri.map, 
-                value.var="rescale", upper = TRUE)
-            Lower.rotated.map <- RotateHeatmap(Matrix=Lower.tri.map, 
-                value.var="rescale", upper = FALSE) 
-            Entire.rotated.map <- rbind(Upper.rotated.map,Lower.rotated.map)
+            Upper.rotated.map <- RotateHeatmap(Matrix = Upper.tri.map,
+                value.var = "rescale", upper = TRUE)
+            Lower.rotated.map <- RotateHeatmap(Matrix = Lower.tri.map,
+                value.var = "rescale", upper = FALSE)
+            Entire.rotated.map <- rbind(Upper.rotated.map, Lower.rotated.map)
             y.coord.breaks <- y.coord.breaks/2
-            y.coord.breaks <- c(rev(y.coord.breaks)*-1,y.coord.breaks)
-            y_axis.coord.labs <- c(rev(y_axis.coord.labs),y_axis.coord.labs)
-        }else{
-            Upper.tri.map <- Matrix.df[Matrix.df$dist >= 0,]
-            Entire.rotated.map <- RotateHeatmap(Matrix=Upper.tri.map, 
-                value.var="rescale", upper = TRUE)
+            y.coord.breaks <- c(rev(y.coord.breaks) * -1, y.coord.breaks)
+            y_axis.coord.labs <- c(rev(y_axis.coord.labs), y_axis.coord.labs)
+        }
+        else {
+            Upper.tri.map <- Matrix.df[Matrix.df$dist >= 0, ]
+            Entire.rotated.map <- HiCBricks:::RotateHeatmap(Matrix = Upper.tri.map,
+                value.var = "rescale", upper = TRUE)
             y.coord.breaks <- y.coord.breaks/2
         }
     }
-
-    # require(ggplot2)
-    Brick_theme <- Get_heatmap_theme(x_axis=x_axis, y_axis=y_axis, 
-        text_size = text_size, x_axis_text_size = x_axis_text_size, 
-        y_axis_text_size = y_axis_text_size, 
-        legend_title_text_size = legend_title_text_size, 
-        legend_text_size = legend_text_size, 
-        title_size = title_size, legend_key_width = legend_key_width, 
-        legend_key_height =legend_key_height)
-    Labels <- Get_heatmap_titles(title = title, x_axis_title = x_axis_title, 
-        y_axis_title = y_axis_title, legend_title = legend_title, 
+    Brick_theme <- HiCBricks:::Get_heatmap_theme(x_axis = x_axis, y_axis = y_axis,
+        text_size = text_size, x_axis_text_size = x_axis_text_size,
+        y_axis_text_size = y_axis_text_size, legend_title_text_size = legend_title_text_size,
+        legend_text_size = legend_text_size, title_size = title_size,
+        legend_key_width = legend_key_width, legend_key_height = legend_key_height)
+    Labels <- HiCBricks:::Get_heatmap_titles(title = title, x_axis_title = x_axis_title,
+        y_axis_title = y_axis_title, legend_title = legend_title,
         x_coords = x_coords, y_coords = y_coords, rotate = rotate)
     Boundaries.obj <- NULL
-    if(!is.null(tad_ranges)){
-        Boundaries.obj <- Format_boundaries_normal_heatmap(Bricks = Bricks, 
-            resolution = resolution, Ranges = tad_ranges, 
-            group_col = group_col, cut_corners = cut_corners, 
-            colour.col = tad_colour_col, colours = colours, 
-            colours_names = colours_names, region.chr = x.coord.parsed['chr'], 
-            region.start = as.numeric(x.coord.parsed['start']), 
-            region.end = as.numeric(x.coord.parsed['end']), distance = distance,
+    if (!is.null(tad_ranges)) {
+        Boundaries.obj <- HiCBricks:::Format_boundaries_normal_heatmap(Bricks = Bricks,
+            resolution = resolution, Ranges = tad_ranges, group_col = group_col,
+            cut_corners = cut_corners, colour.col = tad_colour_col,
+            colours = colours, colours_names = colours_names,
+            region.chr = x.coord.parsed["chr"], region.start = as.numeric(x.coord.parsed["start"]),
+            region.end = as.numeric(x.coord.parsed["end"]), distance = distance,
             rotate = rotate)
     }
-    if(rotate){
+    if (rotate) {
         ids <- xcoords <- ycoords <- NULL
-        ThePlot <- ggplot(Entire.rotated.map, aes(x = xcoords, y = ycoords))
-        ThePlot <- ThePlot + geom_polygon(aes(fill = values, group = ids))
-        xlims <- c(0,max(Entire.rotated.map[,"xcoords"]))
-        ylims <- c(min(Entire.rotated.map[,"ycoords"]),
-            max(Entire.rotated.map[,"ycoords"]))
-        y.coord.breaks <- seq(ceiling(min(Entire.rotated.map[,"ycoords"])),
-            ceiling(max(Entire.rotated.map[,"ycoords"])),
+        ThePlot <- ggplot(Entire.rotated.map, aes(x = xcoords,
+            y = ycoords))
+        ThePlot <- ThePlot + geom_polygon(aes(fill = values,
+            group = ids))
+        xlims <- c(0, max(Entire.rotated.map[, "xcoords"]))
+        ylims <- c(min(Entire.rotated.map[, "ycoords"]), max(Entire.rotated.map[,
+            "ycoords"]))
+        y.coord.breaks <- seq(ceiling(min(Entire.rotated.map[,
+            "ycoords"])), ceiling(max(Entire.rotated.map[, "ycoords"])),
             length.out = y_axis_num_breaks)
-        y_axis.coord.labs <- y.coord.breaks*2
-    }else{
+        y_axis.coord.labs <- y.coord.breaks * 2
+    }
+    else {
         Matrix.df$row <- Matrix.df$row - 0.5
         Matrix.df$col <- Matrix.df$col - 0.5
         ThePlot <- ggplot(Matrix.df, aes(x = row, y = col))
         ThePlot <- ThePlot + geom_tile(aes(fill = rescale))
-        xlims <- c(min(Matrix.df$row) - 0.5,max(Matrix.df$row) + 0.5)
-        ylims <- c(min(Matrix.df$col) - 0.5,max(Matrix.df$col) + 0.5)
+        xlims <- c(min(Matrix.df$row) - 0.5, max(Matrix.df$row) +
+            0.5)
+        ylims <- c(min(Matrix.df$col) - 0.5, max(Matrix.df$col) +
+            0.5)
     }
-    if(!is.null(tad_ranges)){
+    if (!is.null(tad_ranges)) {
         line.group <- x <- y <- NULL
-        ThePlot <- ThePlot + geom_line(data = Boundaries.obj, 
-            aes(x = x, y = y, group = line.group, colour = colours), 
-            size = line_width) 
+        ThePlot <- ThePlot + geom_line(data = Boundaries.obj,
+            aes(x = x, y = y, group = line.group, colour = colours),
+            size = line_width)
         ThePlot <- ThePlot + scale_colour_manual(values = colours)
     }
-    ThePlot <- ThePlot + scale_x_continuous(limits = xlims, expand = c(0,0),
-        breaks = x.coord.breaks, labels = x_axis.coord.labs)
-    ThePlot <- ThePlot + scale_y_continuous(limits = ylims, expand = c(0,0),
-        breaks = y.coord.breaks, labels = y_axis.coord.labs)
-    ThePlot <- ThePlot + scale_fill_gradientn(legend_title,values = Value.dist, 
+    ThePlot <- ThePlot + scale_x_continuous(limits = xlims, expand = c(0,
+        0), breaks = x.coord.breaks, labels = x_axis.coord.labs)
+    ThePlot <- ThePlot + scale_y_continuous(limits = ylims, expand = c(0,
+        0), breaks = y.coord.breaks, labels = y_axis.coord.labs)
+    ThePlot <- ThePlot + scale_fill_gradientn(legend_title, values = Value.dist,
         breaks = Colour.breaks, labels = Colour.labs, colors = Colours)
-    ThePlot<-ThePlot+ Brick_theme
-    # return(Entire.rotated.map)
-    ThePlot<-ThePlot+labs(title = Labels['title'], x = Labels['x_axis'], 
-        y = Labels['y_axis'])
-    ggsave(filename = File, plot = ThePlot, width = width, height = height, 
+    ThePlot <- ThePlot + Brick_theme
+    ThePlot <- ThePlot + labs(title = Labels["title"], x = Labels["x_axis"],
+        y = Labels["y_axis"])
+    ggsave(filename = File, plot = ThePlot, width = width, height = height,
         units = units)
-    if(return_object){
+    if (return_object) {
         return(ThePlot)
-    }else{
+    }
+    else {
         return(TRUE)
     }
 }

--- a/R/viz_art_functions.R
+++ b/R/viz_art_functions.R
@@ -31,6 +31,10 @@
 #' A character vector of length 1 specifying the coordinates from where to fetch
 #' the data.
 #' 
+#' @param invert_coords \strong{Optional}. Default FALSE.
+#' A boolean (TRUE or FALSE) of length 1 specifying whether the coordinates in the
+#' upper triangle of the data should be plotted transposed in the lower triangle.
+#'
 #' @param FUN \strong{Optional}. Default NULL
 #' If any sort of transformations should be applied to the data before plotting.
 #' Such as, log10 or log2 transformations. 

--- a/R/viz_art_functions.R
+++ b/R/viz_art_functions.R
@@ -31,7 +31,8 @@
 #' A character vector of length 1 specifying the coordinates from where to fetch
 #' the data.
 #' 
-#' @param invert_coords \strong{Optional}. Default FALSE.
+#' @param invert_coords \strong{Optional}
+#' Default FALSE.
 #' A boolean (TRUE or FALSE) of length 1 specifying whether the coordinates in the
 #' upper triangle of the data should be plotted transposed in the lower triangle.
 #'

--- a/R/viz_art_functions.R
+++ b/R/viz_art_functions.R
@@ -206,37 +206,37 @@ Brick_vizart_plot_heatmap <- function (File, Bricks, resolution,
         stop("Bricks expects an argument of type list.",
              " Please refer to the vignette to understand the parameter.")
     }
-    Matrix.df <- HiCBricks:::Get_one_or_two_brick_regions(Bricks = Bricks,
+    Matrix.df <- Get_one_or_two_brick_regions(Bricks = Bricks,
         resolution = resolution, x_coords = x_coords, y_coords = y_coords,
         distance = distance, value_cap = value_cap, FUN = FUN)
     if (nrow(Matrix.df) == 0) {
         stop("The matrix was empty!")
     }
     list_of_coords <- list(x_coords = x_coords, y_coords = y_coords)
-    Parsed_string <- HiCBricks:::._Parse_genomic_coordinates(list_of_coords)
+    Parsed_string <- ._Parse_genomic_coordinates(list_of_coords)
     x.coord.parsed <- Parsed_string[["x_coords"]]
     y.coord.parsed <- Parsed_string[["y_coords"]]
-    x.coord.breaks <- HiCBricks:::make_axis_coord_breaks(from = min(Matrix.df$row),
+    x.coord.breaks <- make_axis_coord_breaks(from = min(Matrix.df$row),
         to = max(Matrix.df$row), how.many = x_axis_num_breaks,
         two.sample = FALSE)
-    x_axis.coord.labs <- HiCBricks:::Make_axis_labels(Brick = Bricks[[1]],
+    x_axis.coord.labs <- Make_axis_labels(Brick = Bricks[[1]],
         resolution = resolution, chr = x.coord.parsed["chr"],
         positions = x.coord.breaks)
     two.sample <- (rotate & length(Bricks) == 2)
-    y.coord.breaks <- HiCBricks:::make_axis_coord_breaks(from = min(Matrix.df$col),
+    y.coord.breaks <- make_axis_coord_breaks(from = min(Matrix.df$col),
         to = max(Matrix.df$col), how.many = y_axis_num_breaks,
         two.sample = two.sample)
-    y_axis.coord.labs <- HiCBricks:::Make_axis_labels(Brick = Bricks[[1]],
+    y_axis.coord.labs <- Make_axis_labels(Brick = Bricks[[1]],
         resolution = resolution, chr = y.coord.parsed["chr"],
         positions = abs(y.coord.breaks))
-    Colours <- HiCBricks:::Make_colours(palette = palette, extrapolate_on = extrapolate_on,
+    Colours <- Make_colours(palette = palette, extrapolate_on = extrapolate_on,
         direction = col_direction)
     two.sample <- (length(Bricks) == 2)
-    Matrix.df$rescale <- HiCBricks:::rescale_values_for_colours(Object = Matrix.df,
+    Matrix.df$rescale <- rescale_values_for_colours(Object = Matrix.df,
         two.sample = two.sample)
-    Value.dist <- HiCBricks:::make_colour_breaks(Object = Matrix.df, how.many = length(Colours),
+    Value.dist <- make_colour_breaks(Object = Matrix.df, how.many = length(Colours),
         two.sample = two.sample)
-    Legend.breaks.list <- HiCBricks:::get_legend_breaks(Object = Matrix.df,
+    Legend.breaks.list <- get_legend_breaks(Object = Matrix.df,
         how.many = 5, value_cap = value_cap, colours = Colours,
         two.sample = two.sample)
     Colour.breaks <- Legend.breaks.list[["col.breaks"]]
@@ -260,22 +260,22 @@ Brick_vizart_plot_heatmap <- function (File, Bricks, resolution,
         }
         else {
             Upper.tri.map <- Matrix.df[Matrix.df$dist >= 0, ]
-            Entire.rotated.map <- HiCBricks:::RotateHeatmap(Matrix = Upper.tri.map,
+            Entire.rotated.map <- RotateHeatmap(Matrix = Upper.tri.map,
                 value.var = "rescale", upper = TRUE)
             y.coord.breaks <- y.coord.breaks/2
         }
     }
-    Brick_theme <- HiCBricks:::Get_heatmap_theme(x_axis = x_axis, y_axis = y_axis,
+    Brick_theme <- Get_heatmap_theme(x_axis = x_axis, y_axis = y_axis,
         text_size = text_size, x_axis_text_size = x_axis_text_size,
         y_axis_text_size = y_axis_text_size, legend_title_text_size = legend_title_text_size,
         legend_text_size = legend_text_size, title_size = title_size,
         legend_key_width = legend_key_width, legend_key_height = legend_key_height)
-    Labels <- HiCBricks:::Get_heatmap_titles(title = title, x_axis_title = x_axis_title,
+    Labels <- Get_heatmap_titles(title = title, x_axis_title = x_axis_title,
         y_axis_title = y_axis_title, legend_title = legend_title,
         x_coords = x_coords, y_coords = y_coords, rotate = rotate)
     Boundaries.obj <- NULL
     if (!is.null(tad_ranges)) {
-        Boundaries.obj <- HiCBricks:::Format_boundaries_normal_heatmap(Bricks = Bricks,
+        Boundaries.obj <- Format_boundaries_normal_heatmap(Bricks = Bricks,
             resolution = resolution, Ranges = tad_ranges, group_col = group_col,
             cut_corners = cut_corners, colour.col = tad_colour_col,
             colours = colours, colours_names = colours_names,

--- a/R/viz_art_functions.R
+++ b/R/viz_art_functions.R
@@ -213,30 +213,22 @@ Brick_vizart_plot_heatmap <- function (File, Bricks, resolution,
         stop("The matrix was empty!")
     }
     list_of_coords <- list(x_coords = x_coords, y_coords = y_coords)
-    print(list_of_coords)
     Parsed_string <- HiCBricks:::._Parse_genomic_coordinates(list_of_coords)
     x.coord.parsed <- Parsed_string[["x_coords"]]
     y.coord.parsed <- Parsed_string[["y_coords"]]
-    print(x.coord.parsed)
-    print(y.coord.parsed)
     x.coord.breaks <- HiCBricks:::make_axis_coord_breaks(from = min(Matrix.df$row),
         to = max(Matrix.df$row), how.many = x_axis_num_breaks,
         two.sample = FALSE)
-    print(x.coord.breaks)
     x_axis.coord.labs <- HiCBricks:::Make_axis_labels(Brick = Bricks[[1]],
         resolution = resolution, chr = x.coord.parsed["chr"],
         positions = x.coord.breaks)
-    print(x_axis.coord.labs)
     two.sample <- (rotate & length(Bricks) == 2)
-    print(str(Matrix.df))
     y.coord.breaks <- HiCBricks:::make_axis_coord_breaks(from = min(Matrix.df$col),
         to = max(Matrix.df$col), how.many = y_axis_num_breaks,
         two.sample = two.sample)
-   print(y.coord.breaks)
     y_axis.coord.labs <- HiCBricks:::Make_axis_labels(Brick = Bricks[[1]],
         resolution = resolution, chr = y.coord.parsed["chr"],
         positions = abs(y.coord.breaks))
-    print(y_axis.coord.labs)
     Colours <- HiCBricks:::Make_colours(palette = palette, extrapolate_on = extrapolate_on,
         direction = col_direction)
     two.sample <- (length(Bricks) == 2)

--- a/man/Brick_vizart_plot_heatmap.Rd
+++ b/man/Brick_vizart_plot_heatmap.Rd
@@ -5,47 +5,47 @@
 \title{Create the entire HDF5 structure and load the bintable}
 \usage{
 Brick_vizart_plot_heatmap(
-    File,
-    Bricks,
-    resolution,
-    x_coords,
-    y_coords,
-    invert_coords = FALSE,
-    FUN = NULL,
-    value_cap = NULL,
-    distance = NULL,
-    rotate = FALSE,
-    x_axis = TRUE,
-    x_axis_title = NULL,
-    y_axis = TRUE,
-    y_axis_title = NULL,
-    title = NULL,
-    legend_title = NULL,
-    return_object = FALSE,
-    x_axis_num_breaks = 5,
-    y_axis_num_breaks = 5,
-    palette,
-    col_direction = 1,
-    extrapolate_on = NULL,
-    x_axis_text_size = 10,
-    y_axis_text_size = 10,
-    text_size = 10,
-    legend_title_text_size = 8,
-    legend_text_size = 8,
-    title_size = 10,
-    tad_ranges = NULL,
-    group_col = NULL,
-    tad_colour_col = NULL,
-    colours = NULL,
-    colours_names = NULL,
-    cut_corners = FALSE,
-    highlight_points = NULL,
-    width = 10,
-    height = 6,
-    line_width = 0.5,
-    units = "cm",
-    legend_key_width = unit(3, "cm"),
-    legend_key_height = unit(0.5, "cm")
+  File,
+  Bricks,
+  resolution,
+  x_coords,
+  y_coords,
+  invert_coords = FALSE,
+  FUN = NULL,
+  value_cap = NULL,
+  distance = NULL,
+  rotate = FALSE,
+  x_axis = TRUE,
+  x_axis_title = NULL,
+  y_axis = TRUE,
+  y_axis_title = NULL,
+  title = NULL,
+  legend_title = NULL,
+  return_object = FALSE,
+  x_axis_num_breaks = 5,
+  y_axis_num_breaks = 5,
+  palette,
+  col_direction = 1,
+  extrapolate_on = NULL,
+  x_axis_text_size = 10,
+  y_axis_text_size = 10,
+  text_size = 10,
+  legend_title_text_size = 8,
+  legend_text_size = 8,
+  title_size = 10,
+  tad_ranges = NULL,
+  group_col = NULL,
+  tad_colour_col = NULL,
+  colours = NULL,
+  colours_names = NULL,
+  cut_corners = FALSE,
+  highlight_points = NULL,
+  width = 10,
+  height = 6,
+  line_width = 0.5,
+  units = "cm",
+  legend_key_width = unit(3, "cm"),
+  legend_key_height = unit(0.5, "cm")
 )
 }
 \arguments{
@@ -69,7 +69,8 @@ the data.}
 A character vector of length 1 specifying the coordinates from where to fetch
 the data.}
 
-\item{invert_coords}} {\strong{Optional}. Default FALSE.
+\item{invert_coords}{\strong{Optional}
+Default FALSE.
 A boolean (TRUE or FALSE) of length 1 specifying whether the coordinates in the
 upper triangle of the data should be plotted transposed in the lower triangle.}
 
@@ -229,9 +230,9 @@ out_dir <- file.path(tempdir(), "vizart_test")
 dir.create(out_dir)
 
 My_BrickContainer <- Create_many_Bricks(BinTable = Bintable.path, 
-    bin_delim = " ", output_directory = out_dir, file_prefix = "Test",
-    experiment_name = "Vignette Test", resolution = 100000,
-    remove_existing = TRUE)
+  bin_delim = " ", output_directory = out_dir, file_prefix = "Test",
+  experiment_name = "Vignette Test", resolution = 100000,
+  remove_existing = TRUE)
 
 Matrix_file <- system.file(file.path("extdata", 
 "Sexton2012_yaffetanay_CisTrans_100000_corrected_chr3R.txt.gz"), 

--- a/man/Brick_vizart_plot_heatmap.Rd
+++ b/man/Brick_vizart_plot_heatmap.Rd
@@ -10,6 +10,7 @@ Brick_vizart_plot_heatmap(
     resolution,
     x_coords,
     y_coords,
+    invert_coords = FALSE,
     FUN = NULL,
     value_cap = NULL,
     distance = NULL,
@@ -67,6 +68,10 @@ the data.}
 \item{y_coords}{\strong{Required}
 A character vector of length 1 specifying the coordinates from where to fetch
 the data.}
+
+\item{invert_coords}} {\strong{Optional}. Default FALSE.
+A boolean (TRUE or FALSE) of length 1 specifying whether the coordinates in the
+upper triangle of the data should be plotted transposed in the lower triangle.}
 
 \item{FUN}{\strong{Optional}. Default NULL
 If any sort of transformations should be applied to the data before plotting.


### PR DESCRIPTION
Adds invert_coords parameter. Backwards compatible with invert_coords = FALSE (default). Allows inverting axes to plot the transpose of brick object. Note the x_coords and y_coords match the x and y axes of plot created but the brick object contains data in the transpose matrix.

Follow up to PR #25 adding features discussed in Issue #18.

Enables:
- inverting the matrix to (optionally) allow plotting the larger chromosome on the x-axis from the same "brick" file

See here for the differences between #25 and #26
https://github.com/Kelly-ST-HRI/HiCBricks/compare/correct-coords...Kelly-ST-HRI:HiCBricks:invert-coords?expand=1